### PR TITLE
Feat: Improved translations in Recipient creation form, added "visitC…

### DIFF
--- a/client_web/src/app/dashboard/recipients.tsx
+++ b/client_web/src/app/dashboard/recipients.tsx
@@ -99,11 +99,11 @@ const Form = ({ item }: { item?: RecipientT }) => {
 			<InputText id="phone" form={f} placeholder={t('t.phone')} />
 			<InputText id="notes" form={f} placeholder={t('t.notes')} />
 			<InputPrice id="hourlyRate" form={f} placeholder={t('t.hourlyRate')} />
-			<MultiSelect id="serviceGroups" form={f} placeholder={t('t.workers')} />
+			<MultiSelect id="serviceGroups" form={f} placeholder={t('t.serviceGroup')} />
 			<Select
 				id="approveBy"
 				form={f}
-				placeholder={t('t.approvedBy')}
+				placeholder={t('t.visitConfirmationMethod')}
 				options={[
 					{ value: 'email', label: t('o.email') },
 					{ value: 'signature', label: t('o.signature') },

--- a/client_web/src/locales/en.locale.json
+++ b/client_web/src/locales/en.locale.json
@@ -105,6 +105,7 @@
 		"services": "Services",
 		"servicesCompleted": "Service Completed",
 		"servicesCompletedHours": "Service Completed Hours",
+		"serviceGroup": "Service Group",
 		"status": "Status",
 		"time": "Time",
 		"timeFrom": "Time From",
@@ -114,6 +115,7 @@
 		"visitLogs": "Visit Logs",
 		"visits": "Visits",
 		"visitsCount": "Visits Count",
+		"visitConfirmationMethod": "Visit Confirmation Method",
 		"workers": "Workers"
 	},
 	"o": {

--- a/client_web/src/locales/lt.locale.json
+++ b/client_web/src/locales/lt.locale.json
@@ -105,6 +105,7 @@
 		"services": "Paslaugos",
 		"servicesCompleted": "Suteikta paslaugų",
 		"servicesCompletedHours": "Kontaktinis laikas",
+		"serviceGroup": "Paslaugų grupė",
 		"status": "Statusas",
 		"time": "Laikas",
 		"timeFrom": "Laikas nuo",
@@ -114,6 +115,7 @@
 		"visitLogs": "Vizitų žurnalas",
 		"visits": "Vizitai",
 		"visitsCount": "Vizitų skaičius",
+		"visitConfirmationMethod": "Vizito patvirtinimo būdas",
 		"workers": "Darbuotojai"
 	},
 	"o": {

--- a/client_web/src/utils/i18n.util.ts
+++ b/client_web/src/utils/i18n.util.ts
@@ -66,6 +66,7 @@ export const lo: Record<string, string> = {
 	services: t('t.services'),
 	servicesCompleted: t('t.servicesCompleted'),
 	servicesCompletedHours: t('t.servicesCompletedHours'),
+	serviceGroup: t('t.serviceGroup'),
 	status: t('t.status'),
 	time: t('t.time'),
 	timeFrom: t('t.timeFrom'),
@@ -75,5 +76,6 @@ export const lo: Record<string, string> = {
 	visitLogs: t('t.visitLogs'),
 	visits: t('t.visits'),
 	visitsCount: t('t.visitsCount'),
+	visitConfirmationMethod: t('t.visitConfirmationMethod'),
 	workers: t('t.workers'),
 }


### PR DESCRIPTION
Task: [SC-123] (**Not 112**)

This PR improves translation accuracy in the Recipient creation form and introduces two new translations, "visitConfirmationMethod" and "serviceGroup", for both Lithuanian and English. Key changes include:

- Refined Translations: Updated several field translations for clarity and accuracy in both languages.
- New Translations: Added "visitConfirmationMethod" for selecting the method of confirming a visit and "serviceGroup" for grouping services.

**Testing**

- Verified that all form fields display updated translations correctly.

![image](https://github.com/user-attachments/assets/123751cf-b284-41b3-aab5-d69d7cad2df2)
