### PR TITLE
Feat: Categories now can be updated/edited

### DIFF
--- a/client_web/src/apis/entities/categories.api.entity.ts
+++ b/client_web/src/apis/entities/categories.api.entity.ts
@@ -9,3 +9,10 @@ export const API_POST_Category = async (data: AddCategoryT) => {
 	if (!role) return toastErr(UsersE.USER_ROLE_NOT_FOUND)
 	return await req.post(`/${role}/entity/categories`, data)
 }
+
+export const API_PATCH_Category = async (data: AddCategoryT, catPid: string) => {
+	const role = useStateUser.getState().user?.role
+	if (!role) return toastErr(UsersE.USER_ROLE_NOT_FOUND)
+		console.log('priejom?')
+	return await req.patch(`/${role}/entity/categories/${catPid}`, data)
+}

--- a/client_web/src/apis/types/entities.api.type.ts
+++ b/client_web/src/apis/types/entities.api.type.ts
@@ -16,6 +16,12 @@ export type GetWorkerVisitT = {
 	recipientName: string
 }
 
+export type CategorieT = {
+    pid: string
+    categoryGroupPid: string
+    name: string
+}
+
 export type RecipientT = {
 	pid: string
 	firstName: string

--- a/client_web/src/app/dashboard/categories.tsx
+++ b/client_web/src/app/dashboard/categories.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { useForm } from '@mariuzm/form'
 
-import { API_POST_Category } from '../../apis/entities/categories.api.entity'
+import { API_PATCH_Category, API_POST_Category } from '../../apis/entities/categories.api.entity'
 import { InputText } from '../../components/BuilderForm/components/InputText'
 import { SelectAPIV2 } from '../../components/BuilderForm/components/Select/Select'
 import { AddCategoryS } from '../../components/BuilderForm/schemas/main.schema'
@@ -10,30 +10,53 @@ import { Table } from '../../components/BuilderTable/Table'
 import { Button } from '../../components/Button'
 import { toastSuccess } from '../../components/Toast'
 import { useT } from '../../utils/i18n.util'
+import type { CategorieT } from '../../apis/types/entities.api.type'
 
 export const CategoriesPage = () => {
 	const t = useT()
-	return <Table tableName="categories" modalTitle={t('createCategory')} Form={Form} />
+	return <Table
+		tableName="categories"
+		modalTitle={t('createCategory')}
+		modalTitleEdit={t('editCategory')}
+		Form={Form}
+		isEditable
+	/>
 }
 
-const Form = () => {
-	const form = useForm(AddCategoryS)
+const Form = ({ item }: { item?: CategorieT }) => {
+	const f = useForm(AddCategoryS)
 	const [isLoading, setIsLoading] = useState(false)
 	const t = useT()
+
+	useEffect(() => {
+		if (item) {
+			console.log('itemas', item)
+			f.setValue('categoryGroup', item.categoryGroupPid);
+			f.setValue('name', item.name);
+			return
+		} else {
+			f.reset();
+		}
+	}, [f, item]);
+
 	return (
 		<form
-			onSubmit={form.handleSubmit(async (formData) => {
+			onSubmit={f.handleSubmit(async (formData) => {
 				setIsLoading(true)
-				await API_POST_Category(formData)
+				const res = item
+					? await API_PATCH_Category(formData, item.pid)
+					: API_POST_Category(formData)
+				if (res) {
+					!item && f.reset()
+					toastSuccess(!item ? 'Category created' : 'Category updated')
+				}
 				setIsLoading(false)
-				form.reset()
-				toastSuccess('Category created successfully')
 			})}
 			style={{ display: 'flex', flexDirection: 'column', gap: 20 }}
 		>
-			<SelectAPIV2 id="categoryGroup" form={form} placeholder={t('categoryGroup')} />
-			<InputText id="name" form={form} placeholder={t('name')} />
-			<Button title={t('create')} type="submit" isSubmitting={isLoading} />
+			<SelectAPIV2 id="categoryGroup" form={f} placeholder={t('t.serviceGroup')} />
+			<InputText id="name" form={f} placeholder={t('name')} />
+			<Button title={item ? t('update') : t('create')} type="submit" isSubmitting={isLoading} />
 		</form>
 	)
 }

--- a/client_web/src/components/BuilderForm/components/Select/Select.tsx
+++ b/client_web/src/components/BuilderForm/components/Select/Select.tsx
@@ -134,6 +134,18 @@ export const SelectAPIV2 = <T extends object>({
 }) => {
 	const [isApiLoading, setIsApiLoading] = useState(false)
 	const [data, setData] = useState<SelectOptionT[]>([])
+
+	useEffect(() => {
+		const loadData = async () => {
+			setIsApiLoading(true)
+			const options = await API_GET_OptionsV2('categories_groups')
+			setData(options)
+			setIsApiLoading(false)
+		}
+
+		loadData()
+	}, [])
+
 	return (
 		<Controller
 			name={id}
@@ -147,7 +159,6 @@ export const SelectAPIV2 = <T extends object>({
 							onChange={onChange}
 							onClick={async () => {
 								setIsApiLoading(true)
-								setData(await API_GET_OptionsV2('categories_groups'))
 								setIsApiLoading(false)
 							}}
 							disabled={isDisabled}

--- a/client_web/src/components/BuilderForm/components/Select/Select.tsx
+++ b/client_web/src/components/BuilderForm/components/Select/Select.tsx
@@ -157,10 +157,6 @@ export const SelectAPIV2 = <T extends object>({
 							classNames={{ input: css.select }}
 							value={value || ''}
 							onChange={onChange}
-							onClick={async () => {
-								setIsApiLoading(true)
-								setIsApiLoading(false)
-							}}
 							disabled={isDisabled}
 							placeholder={placeholder}
 							data={data}

--- a/client_web/src/locales/en.locale.json
+++ b/client_web/src/locales/en.locale.json
@@ -10,6 +10,7 @@
 	"create": "Create",
 	"update": "Update",
 	"createCategory": "Create Category",
+	"editCategory": "Edit Category",
 	"createProvider": "Create Provider",
 	"createRecipient": "Create Recipient",
 	"editRecipient": "Edit Recipient",

--- a/client_web/src/locales/lt.locale.json
+++ b/client_web/src/locales/lt.locale.json
@@ -10,6 +10,7 @@
 	"create": "Sukurti",
 	"update": "Atnaujinti",
 	"createCategory": "Pridėti kategoriją",
+	"editCategory": "Redaguoti kategoriją",
 	"createProvider": "Pridėti paslaugos teikėją",
 	"createRecipient": "Pridėti paslaugos gavėją",
 	"editRecipient": "Redaguoti paslaugos gavėją",

--- a/server_api/src/app.ts
+++ b/server_api/src/app.ts
@@ -5,7 +5,7 @@ import cors from '@fastify/cors'
 import { TypeBoxValidatorCompiler, type TypeBoxTypeProvider } from '@fastify/type-provider-typebox'
 
 import { getTable } from './routes/admin/_main.route'
-import { apCreateCategory } from './routes/admin/categories.route'
+import { apCreateCategory, apGetCategory, apUpdateCategory } from './routes/admin/categories.route'
 import { createProvider } from './routes/admin/providers.route'
 import { createRecipient } from './routes/admin/recipients.route'
 import { createService } from './routes/admin/services.route'
@@ -80,6 +80,8 @@ Fastify()
 				.get('/:tableName', getTable)
 				.get('/options/:entity', apGetOptions)
 				.post('/categories', apCreateCategory)
+				.get('/categories/:categoryPid', apGetCategory)
+				.patch('/categories/:categoryPid', apUpdateCategory)
 				.post('/providers', createProvider)
 				.post('/recipients', createRecipient)
 				.post('/services', createService)
@@ -97,6 +99,8 @@ Fastify()
 				.get('/options/:entity', apGetOptions)
 				.get('/categories', pGetCategories)
 				.post('/categories', apCreateCategory)
+				.get('/categories/:categoryPid', apGetCategory)
+				.patch('/categories/:categoryPid', apUpdateCategory)
 				.get('/recipients', pGetRecipients)
 				.get('/recipients/options', pGetRecipientsOptions)
 				.get('/recipients/:recipientPid', pGetRecipient)

--- a/server_api/src/db/queries/categories.query.ts
+++ b/server_api/src/db/queries/categories.query.ts
@@ -1,5 +1,5 @@
 import { dbk } from '../../providers/kysely.provider'
-import type { CreateCategoryT } from '../../routes/admin/categories.route'
+import type { CreateCategoryT, EditCategoryT } from '../../routes/admin/categories.route'
 import { err } from '../../utils/err.util'
 import { genId } from '../../utils/genId.util'
 
@@ -19,10 +19,45 @@ export const q_ap_create_category = async (body: CreateCategoryT, tokenPid: stri
 }
 
 export const q_ap_get_categories_t = async (tokenPid: string) => {
-	let q = dbk.selectFrom('categories').select(['pid', 'name', 'created_at']).orderBy('id', 'desc')
-	if (tokenPid) q = q.where('created_by', '=', tokenPid)
+	let q = dbk
+		.selectFrom('categories')
+		.select(['pid', 'name', 'created_at', 'category_group_pid'])
+		.orderBy('id', 'desc')
+
+	if (tokenPid) {
+		q = q.where('created_by', '=', tokenPid)
+	}
+
 	return await q.execute()
 }
+
+export const q_ap_update_category = async (body: EditCategoryT, categoryPid: string, createdBy?: string) => {
+	let query = dbk.updateTable('categories').set({
+		category_group_pid: body.categoryGroup,
+		name: body.name,
+	})
+
+	if (createdBy) {
+		query = query.where('created_by', '=', createdBy)
+	}
+
+	const updatedCategory = await query
+		.where('pid', '=', categoryPid)
+		.returning(['pid', 'name', 'category_group_pid', 'created_at', 'created_by'])
+		.executeTakeFirst()
+
+	if (!updatedCategory) throw err(404, 'Category not found or access denied')
+	return updatedCategory
+}
+
+export const q_get_category_by_id = async (categoryPid: string) => {
+	const category = await dbk
+	  .selectFrom('categories')
+	  .select(['pid', 'name', 'category_group_pid', 'created_at', 'created_by'])
+	  .where('pid', '=', categoryPid)
+	  .executeTakeFirst()
+	return category || null
+  }
 
 export const q_get_categories_opt = async (tokenPid: string) => {
 	return await dbk

--- a/server_api/src/routes/admin/categories.route.ts
+++ b/server_api/src/routes/admin/categories.route.ts
@@ -2,10 +2,45 @@ import type { FastifyReply } from 'fastify'
 
 import { Type as t } from '@sinclair/typebox'
 
-import { q_ap_create_category } from '../../db/queries/categories.query'
+import { q_ap_create_category, q_ap_update_category, q_get_category_by_id } from '../../db/queries/categories.query'
 import type { FastReqT } from '../../types/fastify.type'
 
-const CreateCategoryS = {
+export const GetCategoryS = {
+	params: t.Object({ categoryPid: t.String() }, { additionalProperties: false }),
+}
+export type GetCategoryParamsT = typeof GetCategoryS.params.static
+
+export const apGetCategory = {
+	schema: GetCategoryS,
+	handler: async (req: FastReqT<typeof GetCategoryS>, res: FastifyReply) => {
+		const { categoryPid } = req.params
+		const category = await q_get_category_by_id(categoryPid)
+		if (!category) {
+			res.code(404).send({ message: 'Category not found' })
+		} else {
+			res.code(200).send(category)
+		}
+	},
+}
+
+
+const EditCategoryS = {
+	params: t.Object({ categoryPid: t.String() }, { additionalProperties: false }),
+	body: t.Object({ categoryGroup: t.String(), name: t.String() }, { additionalProperties: false }),
+}
+
+export type EditCategoryT = typeof EditCategoryS.body.static
+
+export const apUpdateCategory = {
+	schema: EditCategoryS,
+	handler: async (req: FastReqT<typeof EditCategoryS>, res: FastifyReply) => {
+		const { categoryPid } = req.params
+		const updatedCategory = await q_ap_update_category(req.body, categoryPid, req.token.pid)
+		res.code(200).send(updatedCategory)
+	},
+}
+
+export const CreateCategoryS = {
 	body: t.Object({ categoryGroup: t.String(), name: t.String() }, { additionalProperties: false }),
 }
 


### PR DESCRIPTION
SC-118

**Category Update**

This update introduces a feature that allows both admin and provider roles to update/edit category entries. Changes allow users to change the service group and name fields in a category entry.

![image](https://github.com/user-attachments/assets/1ee9a531-8ff9-4ba2-a34c-8e08a0f116e0)
